### PR TITLE
Add new feature to delete meetings

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.meeting.Meeting;
+
+/**
+ * Deletes a person identified using it's displayed index from the address book.
+ */
+public class DeleteMeetingCommand extends Command {
+
+    public static final String COMMAND_WORD = "delMeeting";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Deletes the meeting identified by the index number used in the displayed meeting cards.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_MEETING_SUCCESS = "Deleted Meeting: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteMeetingCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Meeting> lastShownMeetingList = model.getFilteredMeetingList();
+
+        if (targetIndex.getZeroBased() >= lastShownMeetingList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_MEETING_DISPLAYED_INDEX);
+        }
+
+        Meeting meetingToDelete = lastShownMeetingList.get(targetIndex.getZeroBased());
+        model.deleteMeeting(meetingToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, meetingToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof DeleteMeetingCommand // instanceof handles nulls
+            && targetIndex.equals(((DeleteMeetingCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,24 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddPersonToMeetingCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CreateMeetingCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeletePersonFromMeetingCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.EditMeetingCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FilterMeetingCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.FindMeetingCommand;
-import seedu.address.logic.commands.FindTagCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.ListMeetingCommand;
-import seedu.address.logic.commands.SortMeetingsCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -103,6 +86,9 @@ public class AddressBookParser {
 
         case SortMeetingsCommand.COMMAND_WORD:
             return new SortMeetingsCommandParser().parse(arguments);
+
+        case DeleteMeetingCommand.COMMAND_WORD:
+            return new DeleteMeetingCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteMeetingCommandParser.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeleteMeetingCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteMeetingCommandParser implements Parser<DeleteMeetingCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteMeetingCommand
+     * and returns a DeleteMeetingCommand object for execution.
+     * @return A command to delete a Meeting
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteMeetingCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteMeetingCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteMeetingCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}


### PR DESCRIPTION
Currently the user is unable to delete meetings
if they decide to cancel or reschedule existing meetings

Adding a command to do delete a meeting from the UI and storage allows users to better organise and manage their meetings.